### PR TITLE
Feature/configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ballantine (0.1.5.pre.rc2)
+    ballantine (0.1.5)
       reline
       thor (~> 1.2.1)
 

--- a/lib/ballantine.rb
+++ b/lib/ballantine.rb
@@ -12,7 +12,11 @@ require_relative "ballantine/commit"
 require_relative "ballantine/cli"
 
 module Ballantine
-  class Error < StandardError; end
+  class Error < StandardError
+    # @return [Array<String>, NilClass]
+    def backtrace = Config.instance.verbose ? super : nil
+  end
+
   class NotAllowed < Error; end
   class InvalidParameter < Error; end
   class AssertionFailed < Error; end

--- a/lib/ballantine/author.rb
+++ b/lib/ballantine/author.rb
@@ -36,8 +36,6 @@ module Ballantine
 
     # @return [Boolean]
     def print_commits
-      Config.instance.print_log(binding) if Config.instance.verbose
-
       puts "\n" + "@#{name}".green
       commits_hash.each do |repo_name, commits|
         count, word = retrieve_count_and_word(commits)
@@ -54,8 +52,6 @@ module Ballantine
     # reference: https://api.slack.com/messaging/composing/layouts#building-attachments
     # @return [Hash]
     def slack_message
-      Config.instance.print_log(binding) if Config.instance.verbose
-
       message = commits_hash.map do |repo_name, commits|
         count, word = retrieve_count_and_word(commits)
         "*#{repo_name}*: #{count} new #{word}\n" \

--- a/lib/ballantine/author.rb
+++ b/lib/ballantine/author.rb
@@ -36,7 +36,7 @@ module Ballantine
 
     # @return [Boolean]
     def print_commits
-      conf.print_log(binding) if conf.verbose
+      Config.instance.print_log(binding) if Config.instance.verbose
 
       puts "\n" + "@#{name}".green
       commits_hash.each do |repo_name, commits|
@@ -54,7 +54,7 @@ module Ballantine
     # reference: https://api.slack.com/messaging/composing/layouts#building-attachments
     # @return [Hash]
     def slack_message
-      conf.print_log(binding) if conf.verbose
+      Config.instance.print_log(binding) if Config.instance.verbose
 
       message = commits_hash.map do |repo_name, commits|
         count, word = retrieve_count_and_word(commits)
@@ -69,8 +69,6 @@ module Ballantine
     end
 
     private
-
-    def conf = Config.instance
 
     # @param [Array<Commit>] commits
     # @param [Array(Integer, String)] count, word

--- a/lib/ballantine/cli.rb
+++ b/lib/ballantine/cli.rb
@@ -89,7 +89,7 @@ module Ballantine
       end
 
       if uncommitted.any? && Config.instance.raise_uncommitted?
-        raise NotAllowed, "ERROR: Uncommitted file exists. stash or commit uncommitted files.\n#{uncommitted.join("\n")}"
+        raise NotAllowed, "ERROR: Uncommitted file exists. stash or commit uncommitted files.\n\t#{uncommitted.join("\n\t")}"
       end
 
       if target == source

--- a/lib/ballantine/cli.rb
+++ b/lib/ballantine/cli.rb
@@ -56,10 +56,10 @@ module Ballantine
       init_variables(target, source, **options)
 
       # check commits
-      check_commits(**options)
+      check_commits
 
       # print commits
-      print_commits(target, source, **options)
+      print_commits(target, source)
     end
 
     desc "version", "Display version information about ballntine"
@@ -120,9 +120,8 @@ module Ballantine
       true
     end
 
-    # @param [Hash] options
     # @return [Boolean]
-    def check_commits(**options)
+    def check_commits
       conf.print_log(binding) if conf.verbose
 
       repo.check_commits
@@ -132,9 +131,8 @@ module Ballantine
 
     # @param [String] target
     # @param [String] source
-    # @param [Hash] options
     # @return [Boolean]
-    def print_commits(target, source, **options)
+    def print_commits(target, source)
       conf.print_log(binding) if conf.verbose
 
       authors = Author.all

--- a/lib/ballantine/cli.rb
+++ b/lib/ballantine/cli.rb
@@ -6,6 +6,9 @@ module Ballantine
 
     attr_reader :repo
 
+    # @return [Array<String>]
+    attr_reader :uncommitted
+
     class << self
       def exit_on_failure? = exit(1)
     end
@@ -14,7 +17,7 @@ module Ballantine
     option "force", type: :boolean, aliases: "-f", default: false, desc: "Initialize forcely if already initialized."
     desc "init", "Initialize ballantine"
     def init
-      conf.init_file(force: options["force"])
+      Config.instance.init_file(force: options["force"])
 
       puts "🥃 Initialized ballantine."
 
@@ -25,8 +28,8 @@ module Ballantine
     option "verbose", type: :boolean, default: false, desc: "Print a progress."
     desc "config [--env] [KEY] [VALUE]", "Set ballantine's configuration"
     def config(key = nil, value = nil)
-      conf.verbose = options["verbose"]
-      puts "$ ballantine config #{key} #{value}" if conf.verbose
+      Config.instance.verbose = options["verbose"]
+      puts "$ ballantine config #{key} #{value}" if Config.instance.verbose
 
       # check environment value
       if Config::AVAILABLE_ENVIRONMENTS.map { |key| !options[key] }.reduce(:&)
@@ -38,8 +41,8 @@ module Ballantine
       env = Config::AVAILABLE_ENVIRONMENTS.find { |key| options[key] }
       raise AssertionFailed, "Environment value must exist: #{env}" if env.nil?
 
-      conf.env = env
-      value ? conf.set_data(key, value) : conf.print_data(key)
+      Config.instance.env = env
+      value ? Config.instance.set_data(key, value) : Config.instance.print_data(key)
 
       true
     end
@@ -48,11 +51,8 @@ module Ballantine
     option Config::TYPE_SLACK, type: :boolean, aliases: "-s", default: false, desc: "Send to slack using slack webhook URL."
     desc "diff [TARGET] [SOURCE]", "Diff commits between TARGET and SOURCE"
     def diff(target, source = %x(git rev-parse --abbrev-ref HEAD).chomp)
-      conf.verbose = options["verbose"]
-      puts "$ ballantine diff #{target} #{source}" if conf.verbose
-
-      # stash uncommitted files
-      save_stash if conf.with_stash?
+      Config.instance.verbose = options["verbose"]
+      puts "$ ballantine diff #{target} #{source}" if Config.instance.verbose
 
       # validate arguments
       validate(target, source, **options)
@@ -67,7 +67,7 @@ module Ballantine
       print_commits(target, source)
 
       # restore stash
-      restore_stash if conf.with_stash?
+      restore_stash if @uncommitted.any?
 
       true
     end
@@ -81,28 +81,30 @@ module Ballantine
 
     private
 
-    def conf = Config.instance
-
     # @param [String] target
     # @param [String] source
     # @param [Hash] options
     # @return [NilClass] nil
     def validate(target, source, **options)
-      conf.print_log(binding) if conf.verbose
+      Config.instance.print_log(binding) if Config.instance.verbose
 
       if Dir[".git"].empty?
         raise NotAllowed, "ERROR: There is no \".git\" in #{Dir.pwd}."
       end
 
-      if !conf.with_stash? && (uncommitted = %x(git diff HEAD --name-only).split("\n")).any?
-        raise NotAllowed, "ERROR: Uncommitted file exists. stash or commit uncommitted files.\n#{uncommitted.join("\n")}"
+      if (@uncommitted = %x(git diff HEAD --name-only).split("\n")).any?
+        if Config.instance.with_stash?
+          save_stash
+        else
+          raise NotAllowed, "ERROR: Uncommitted file exists. stash or commit uncommitted files.\n#{@uncommitted.join("\n")}"
+        end
       end
 
       if target == source
         raise NotAllowed, "ERROR: target(#{target}) and source(#{source}) can't be equal."
       end
 
-      if options[Config::TYPE_SLACK] && !conf.get_data(Config::KEY_SLACK_WEBHOOK)
+      if options[Config::TYPE_SLACK] && !Config.instance.get_data(Config::KEY_SLACK_WEBHOOK)
         raise NotAllowed, "ERROR: Can't find any slack webhook. Set slack webhook using `ballantine config --#{Config::ENV_LOCAL} slack_webhook [YOUR_WEBHOOK]'."
       end
 
@@ -114,12 +116,12 @@ module Ballantine
     # @param [Hash] options
     # @return [Boolean]
     def init_variables(target, source, **options)
-      conf.print_log(binding) if conf.verbose
+      Config.instance.print_log(binding) if Config.instance.verbose
 
       # check commits are newest
       system("git pull -f &> /dev/null")
 
-      conf.print_type = options[Config::TYPE_SLACK] ? Config::TYPE_SLACK : Config::TYPE_TERMINAL
+      Config.instance.print_type = options[Config::TYPE_SLACK] ? Config::TYPE_SLACK : Config::TYPE_TERMINAL
       @repo = Repository.find_or_create_by(
         path: Dir.pwd,
         remote_url: %x(git config --get remote.origin.url).chomp,
@@ -132,7 +134,7 @@ module Ballantine
 
     # @return [Boolean]
     def check_commits
-      conf.print_log(binding) if conf.verbose
+      Config.instance.print_log(binding) if Config.instance.verbose
 
       repo.check_commits
 
@@ -143,7 +145,7 @@ module Ballantine
     # @param [String] source
     # @return [Boolean]
     def print_commits(target, source)
-      conf.print_log(binding) if conf.verbose
+      Config.instance.print_log(binding) if Config.instance.verbose
 
       authors = Author.all
       if authors.empty?
@@ -152,7 +154,7 @@ module Ballantine
 
       number = authors.size
 
-      case conf.print_type
+      case Config.instance.print_type
       when Config::TYPE_TERMINAL
         puts_r "Check commits before #{repo.name.red} deployment. (#{target.cyan}...#{source.cyan})", "#{repo.url}/compare/#{repo.from.hash}...#{repo.to.hash}".gray
         puts "Author".yellow + ": #{number}"
@@ -166,7 +168,7 @@ module Ballantine
         # send message to slack
         require "net/http"
         require "uri"
-        uri = URI.parse(conf.get_data(Config::KEY_SLACK_WEBHOOK))
+        uri = URI.parse(Config.instance.get_data(Config::KEY_SLACK_WEBHOOK))
         request = Net::HTTP::Post.new(uri)
         request.content_type = "application/json"
         request.body = JSON.dump({
@@ -179,7 +181,7 @@ module Ballantine
         response = Net::HTTP.start(uri.hostname, uri.port, req_options) { |http| http.request(request) }
         puts response.message
       else
-        raise AssertionFailed, "Unknown print type: #{conf.print_type}"
+        raise AssertionFailed, "Unknown print type: #{Config.instance.print_type}"
       end
 
       true

--- a/lib/ballantine/cli.rb
+++ b/lib/ballantine/cli.rb
@@ -6,9 +6,6 @@ module Ballantine
 
     attr_reader :repo
 
-    # @return [Array<String>]
-    attr_reader :uncommitted
-
     class << self
       def exit_on_failure? = exit(1)
     end
@@ -54,22 +51,22 @@ module Ballantine
       Config.instance.verbose = options["verbose"]
       puts "$ ballantine diff #{target} #{source}" if Config.instance.verbose
 
+      # retrieve uncommitted files
+      uncommitted = retrieve_uncommitted
+
       # validate arguments
-      validate(target, source, **options)
+      validate(target, source, uncommitted, **options)
 
-      # init instance variables
-      init_variables(target, source, **options)
+      with_stash(uncommitted) do
+        # init instance variables
+        init_variables(target, source, **options)
 
-      # check commits
-      check_commits
+        # check commits
+        check_commits
 
-      # print commits
-      print_commits(target, source)
-
-      # restore stash
-      restore_stash if @uncommitted.any?
-
-      true
+        # print commits
+        print_commits(target, source)
+      end
     end
 
     desc "version", "Display version information about ballntine"
@@ -83,19 +80,16 @@ module Ballantine
 
     # @param [String] target
     # @param [String] source
+    # @param [Array<String>] uncommitted
     # @param [Hash] options
     # @return [NilClass] nil
-    def validate(target, source, **options)
+    def validate(target, source, uncommitted, **options)
       if Dir[".git"].empty?
         raise NotAllowed, "ERROR: There is no \".git\" in #{Dir.pwd}."
       end
 
-      if (@uncommitted = %x(git diff HEAD --name-only).split("\n")).any?
-        if Config.instance.with_stash?
-          save_stash
-        else
-          raise NotAllowed, "ERROR: Uncommitted file exists. stash or commit uncommitted files.\n#{@uncommitted.join("\n")}"
-        end
+      if uncommitted.any? && Config.instance.raise_uncommitted?
+        raise NotAllowed, "ERROR: Uncommitted file exists. stash or commit uncommitted files.\n#{uncommitted.join("\n")}"
       end
 
       if target == source
@@ -176,6 +170,23 @@ module Ballantine
       end
 
       true
+    end
+
+    # @param [Array<String>] uncommitted
+    # @return [Boolean]
+    def with_stash(uncommitted)
+      if uncommitted.any? && !Config.instance.raise_uncommitted?
+        save_stash
+        yield
+        restore_stash
+      else
+        yield
+      end
+    end
+
+    # @return [Array<String>]
+    def retrieve_uncommitted
+      %x(git diff HEAD --name-only).split("\n")
     end
 
     # @return [Boolean]

--- a/lib/ballantine/cli.rb
+++ b/lib/ballantine/cli.rb
@@ -86,8 +86,6 @@ module Ballantine
     # @param [Hash] options
     # @return [NilClass] nil
     def validate(target, source, **options)
-      Config.instance.print_log(binding) if Config.instance.verbose
-
       if Dir[".git"].empty?
         raise NotAllowed, "ERROR: There is no \".git\" in #{Dir.pwd}."
       end
@@ -116,8 +114,6 @@ module Ballantine
     # @param [Hash] options
     # @return [Boolean]
     def init_variables(target, source, **options)
-      Config.instance.print_log(binding) if Config.instance.verbose
-
       # check commits are newest
       system("git pull -f &> /dev/null")
 
@@ -134,10 +130,7 @@ module Ballantine
 
     # @return [Boolean]
     def check_commits
-      Config.instance.print_log(binding) if Config.instance.verbose
-
       repo.check_commits
-
       true
     end
 
@@ -145,8 +138,6 @@ module Ballantine
     # @param [String] source
     # @return [Boolean]
     def print_commits(target, source)
-      Config.instance.print_log(binding) if Config.instance.verbose
-
       authors = Author.all
       if authors.empty?
         raise ArgumentError, "ERROR: There is no commits between \"#{target}\" and \"#{source}\""

--- a/lib/ballantine/cli.rb
+++ b/lib/ballantine/cli.rb
@@ -182,6 +182,7 @@ module Ballantine
       else
         yield
       end
+      true
     end
 
     # @return [Array<String>]

--- a/lib/ballantine/cli.rb
+++ b/lib/ballantine/cli.rb
@@ -40,6 +40,8 @@ module Ballantine
 
       conf.env = env
       value ? conf.set_data(key, value) : conf.print_data(key)
+
+      true
     end
 
     option "verbose", type: :boolean, default: false, desc: "Print a progress."
@@ -48,6 +50,9 @@ module Ballantine
     def diff(target, source = %x(git rev-parse --abbrev-ref HEAD).chomp)
       conf.verbose = options["verbose"]
       puts "$ ballantine diff #{target} #{source}" if conf.verbose
+
+      # stash uncommitted files
+      save_stash if conf.with_stash?
 
       # validate arguments
       validate(target, source, **options)
@@ -60,6 +65,11 @@ module Ballantine
 
       # print commits
       print_commits(target, source)
+
+      # restore stash
+      restore_stash if conf.with_stash?
+
+      true
     end
 
     desc "version", "Display version information about ballntine"
@@ -84,7 +94,7 @@ module Ballantine
         raise NotAllowed, "ERROR: There is no \".git\" in #{Dir.pwd}."
       end
 
-      if (uncommitted = %x(git diff HEAD --name-only).split("\n")).any?
+      if !conf.with_stash? && (uncommitted = %x(git diff HEAD --name-only).split("\n")).any?
         raise NotAllowed, "ERROR: Uncommitted file exists. stash or commit uncommitted files.\n#{uncommitted.join("\n")}"
       end
 
@@ -172,6 +182,18 @@ module Ballantine
         raise AssertionFailed, "Unknown print type: #{conf.print_type}"
       end
 
+      true
+    end
+
+    # @return [Boolean]
+    def save_stash
+      %x(git stash save &> /dev/null)
+      true
+    end
+
+    # @return [Boolean]
+    def restore_stash
+      %x(git stash apply &> /dev/null)
       true
     end
   end

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -103,6 +103,9 @@ module Ballantine
       @data[key]
     end
 
+    # @return [Boolean]
+    def stash_uncommitted? = !!get_data(KEY_STASH_UNCOMMITTED)
+
     # @param [Binding] binding
     # @return [NilClass]
     def print_log(binding)

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -102,8 +102,12 @@ module Ballantine
 
     private
 
+    # @return [Hash{String => Object}]
     def empty_data = AVAILABLE_KEYS.map { |key| [key, nil] }.to_h
 
+    # @param [String] key
+    # @param [Object] value
+    # @return [Object]
     def sanitize_value(key, value)
       case key
       when KEY_RAISE_UNCOMMITTED then value == true || value == "true"
@@ -111,6 +115,8 @@ module Ballantine
       end
     end
 
+    # @param [String] env
+    # @return [String]
     def file_path(env = @env)
       case env
       when ENV_LOCAL then "./#{FILE_BALLANTINE_CONFIG}"

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -40,17 +40,16 @@ module Ballantine
       @verbose = false
     end
 
-    # @param [Hash] options
+    # @param [Boolean] force
     # @return [Boolean] result
-    def init_file(**options)
-      raise NotAllowed, "#{FILE_BALLANTINE_CONFIG} already exists." if Dir[file_path].any? && !options[:force]
+    def init_file(force: false)
+      raise NotAllowed, "#{FILE_BALLANTINE_CONFIG} already exists." if Dir[file_path].any? && !force
       File.write(file_path, JSON.pretty_generate(AVAILABLE_KEYS.map { |key| [key, nil] }.to_h))
       @loaded = false
     end
 
-    # @param [Hash] options
     # @return [Boolean] result
-    def load_file(**options)
+    def load_file
       return false if @loaded
       raise NotAllowed, "Can't find #{FILE_BALLANTINE_CONFIG}" if Dir[file_path].empty?
 
@@ -64,9 +63,8 @@ module Ballantine
     end
 
     # @param [String] key
-    # @param [Hash] options
     # @return [Boolean] result
-    def print_data(key, **options)
+    def print_data(key)
       load_file unless @loaded
 
       if key
@@ -84,9 +82,8 @@ module Ballantine
 
     # @param [String] key
     # @param [String] value
-    # @param [Hash] options
     # @return [Stirng] value
-    def set_data(key, value, **options)
+    def set_data(key, value)
       load_file unless @loaded
       raise InvalidParameter, "Key must be within #{AVAILABLE_KEYS}" unless AVAILABLE_KEYS.include?(key)
       @data[key] = value
@@ -95,9 +92,8 @@ module Ballantine
     end
 
     # @param [String] key
-    # @param [Hash] options
     # @return [Stirng] value
-    def get_data(key, **options)
+    def get_data(key)
       load_file unless @loaded
       @data[key]
     end

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -44,7 +44,7 @@ module Ballantine
     # @return [Boolean] result
     def init_file(**options)
       raise NotAllowed, "#{FILE_BALLANTINE_CONFIG} already exists." if Dir[file_path].any? && !options[:force]
-      File.write(file_path, JSON.dump(AVAILABLE_KEYS.map { |key| [key, nil] }.to_h))
+      File.write(file_path, JSON.pretty_generate(AVAILABLE_KEYS.map { |key| [key, nil] }.to_h))
       @loaded = false
     end
 
@@ -90,7 +90,7 @@ module Ballantine
       load_file unless @loaded
       raise InvalidParameter, "Key must be within #{AVAILABLE_KEYS}" unless AVAILABLE_KEYS.include?(key)
       @data[key] = value
-      File.write(file_path, JSON.dump(@data))
+      File.write(file_path, JSON.pretty_generate(@data))
       value
     end
 

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -12,10 +12,10 @@ module Ballantine
       ENV_GLOBAL,
     ].freeze
     KEY_SLACK_WEBHOOK = "slack_webhook"
-    KEY_STASH_UNCOMMITTED = "stash_uncommitted"
+    KEY_WITH_STASH = "with_stash"
     AVAILABLE_KEYS = [
       KEY_SLACK_WEBHOOK,
-      KEY_STASH_UNCOMMITTED,
+      KEY_WITH_STASH,
     ].freeze
     AVAILABLE_PRINT_INSTANCE_VARIABLES = [:@name, :@from, :@to].freeze
 
@@ -99,7 +99,7 @@ module Ballantine
     end
 
     # @return [Boolean]
-    def stash_uncommitted? = get_data(KEY_STASH_UNCOMMITTED)
+    def with_stash? = get_data(KEY_WITH_STASH)
 
     # @param [Binding] binding
     # @return [NilClass]
@@ -119,7 +119,7 @@ module Ballantine
 
     def sanitize_value(key, value)
       case key
-      when KEY_STASH_UNCOMMITTED then value == true || value == "true"
+      when KEY_WITH_STASH then value == true || value == "true"
       else value
       end
     end

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -56,7 +56,7 @@ module Ballantine
       JSON.parse(File.read(file_path)).each do |key, value|
         next unless AVAILABLE_KEYS.include?(key)
 
-        @data[key] = value
+        @data[key] = sanitize_value(key, value)
       end
 
       @loaded = true
@@ -86,7 +86,7 @@ module Ballantine
     def set_data(key, value)
       load_file unless @loaded
       raise InvalidParameter, "Key must be within #{AVAILABLE_KEYS}" unless AVAILABLE_KEYS.include?(key)
-      @data[key] = value
+      @data[key] = sanitize_value(key, value)
       File.write(file_path, JSON.pretty_generate(@data))
       value
     end
@@ -99,7 +99,7 @@ module Ballantine
     end
 
     # @return [Boolean]
-    def stash_uncommitted? = get_data(KEY_STASH_UNCOMMITTED) == true
+    def stash_uncommitted? = get_data(KEY_STASH_UNCOMMITTED)
 
     # @param [Binding] binding
     # @return [NilClass]
@@ -116,6 +116,13 @@ module Ballantine
     private
 
     def empty_data = AVAILABLE_KEYS.map { |key| [key, nil] }.to_h
+
+    def sanitize_value(key, value)
+      case key
+      when KEY_STASH_UNCOMMITTED then value == true || value == "true"
+      else value
+      end
+    end
 
     def file_path(env = @env)
       case env

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -12,10 +12,10 @@ module Ballantine
       ENV_GLOBAL,
     ].freeze
     KEY_SLACK_WEBHOOK = "slack_webhook"
-    KEY_WITH_STASH = "with_stash"
+    KEY_RAISE_UNCOMMITTED = "raise_uncommitted"
     AVAILABLE_KEYS = [
       KEY_SLACK_WEBHOOK,
-      KEY_WITH_STASH,
+      KEY_RAISE_UNCOMMITTED,
     ].freeze
     AVAILABLE_PRINT_INSTANCE_VARIABLES = [:@name, :@from, :@to].freeze
 
@@ -99,7 +99,7 @@ module Ballantine
     end
 
     # @return [Boolean]
-    def with_stash? = get_data(KEY_WITH_STASH)
+    def raise_uncommitted? = get_data(KEY_RAISE_UNCOMMITTED)
 
     private
 
@@ -107,7 +107,7 @@ module Ballantine
 
     def sanitize_value(key, value)
       case key
-      when KEY_WITH_STASH then value == true || value == "true"
+      when KEY_RAISE_UNCOMMITTED then value == true || value == "true"
       else value
       end
     end

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -17,7 +17,6 @@ module Ballantine
       KEY_SLACK_WEBHOOK,
       KEY_RAISE_UNCOMMITTED,
     ].freeze
-    AVAILABLE_PRINT_INSTANCE_VARIABLES = [:@name, :@from, :@to].freeze
 
     attr_reader :data, :loaded
     attr_accessor :env, :print_type, :verbose

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -89,7 +89,7 @@ module Ballantine
     # @return [Stirng] value
     def set_data(key, value, **options)
       load_file unless @loaded
-
+      raise InvalidParameter, "Key must be within #{AVAILABLE_KEYS}" unless AVAILABLE_KEYS.include?(key)
       @data[key] = value
       File.write(file_path, JSON.dump(@data))
       value

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -103,7 +103,7 @@ module Ballantine
     end
 
     # @return [Boolean]
-    def stash_uncommitted? = !!get_data(KEY_STASH_UNCOMMITTED)
+    def stash_uncommitted? = get_data(KEY_STASH_UNCOMMITTED) == true
 
     # @param [Binding] binding
     # @return [NilClass]

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -101,18 +101,6 @@ module Ballantine
     # @return [Boolean]
     def with_stash? = get_data(KEY_WITH_STASH)
 
-    # @param [Binding] binding
-    # @return [NilClass]
-    def print_log(binding)
-      method = caller(1..1)[0][/`([^']*)'/, 1]
-
-      puts [
-        "#{binding.receiver.class.name}##{method}",
-        (binding.receiver.instance_variables & AVAILABLE_PRINT_INSTANCE_VARIABLES).map { |var| "#{var}:#{binding.receiver.instance_variable_get(var).inspect}" }.join(" "),
-        binding.receiver.method(method).parameters.map { |_, arg| arg }.map { |arg| "#{arg}:#{binding.local_variable_get(arg)}" }.join(" "),
-      ].compact.join("\t")
-    end
-
     private
 
     def empty_data = AVAILABLE_KEYS.map { |key| [key, nil] }.to_h

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -44,7 +44,7 @@ module Ballantine
     # @return [Boolean] result
     def init_file(force: false)
       raise NotAllowed, "#{FILE_BALLANTINE_CONFIG} already exists." if Dir[file_path].any? && !force
-      File.write(file_path, JSON.pretty_generate(AVAILABLE_KEYS.map { |key| [key, nil] }.to_h))
+      File.write(file_path, JSON.pretty_generate(empty_data))
       @loaded = false
     end
 
@@ -114,6 +114,8 @@ module Ballantine
     end
 
     private
+
+    def empty_data = AVAILABLE_KEYS.map { |key| [key, nil] }.to_h
 
     def file_path(env = @env)
       case env

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -44,8 +44,7 @@ module Ballantine
     # @return [Boolean] result
     def init_file(**options)
       raise NotAllowed, "#{FILE_BALLANTINE_CONFIG} already exists." if Dir[file_path].any? && !options[:force]
-
-      File.write(file_path, {})
+      File.write(file_path, JSON.dump(AVAILABLE_KEYS.map { |key| [key, nil] }.to_h))
       @loaded = false
     end
 

--- a/lib/ballantine/config.rb
+++ b/lib/ballantine/config.rb
@@ -12,8 +12,10 @@ module Ballantine
       ENV_GLOBAL,
     ].freeze
     KEY_SLACK_WEBHOOK = "slack_webhook"
+    KEY_STASH_UNCOMMITTED = "stash_uncommitted"
     AVAILABLE_KEYS = [
       KEY_SLACK_WEBHOOK,
+      KEY_STASH_UNCOMMITTED,
     ].freeze
     AVAILABLE_PRINT_INSTANCE_VARIABLES = [:@name, :@from, :@to].freeze
 

--- a/lib/ballantine/repository.rb
+++ b/lib/ballantine/repository.rb
@@ -59,8 +59,6 @@ module Ballantine
     # @param [String] source
     # @return [Boolean]
     def init_variables(target, source)
-      Config.instance.print_log(binding) if Config.instance.verbose
-
       current_revision = %x(git rev-parse --abbrev-ref HEAD).chomp
 
       foo = lambda do |hash, context|
@@ -100,8 +98,6 @@ module Ballantine
 
     # @return [Boolean]
     def check_commits
-      Config.instance.print_log(binding) if Config.instance.verbose
-
       authors = retrieve_authors
       authors.each do |author|
         commits = retrieve_commits(author)

--- a/lib/ballantine/repository.rb
+++ b/lib/ballantine/repository.rb
@@ -59,7 +59,7 @@ module Ballantine
     # @param [String] source
     # @return [Boolean]
     def init_variables(target, source)
-      conf.print_log(binding) if conf.verbose
+      Config.instance.print_log(binding) if Config.instance.verbose
 
       current_revision = %x(git rev-parse --abbrev-ref HEAD).chomp
 
@@ -100,7 +100,7 @@ module Ballantine
 
     # @return [Boolean]
     def check_commits
-      conf.print_log(binding) if conf.verbose
+      Config.instance.print_log(binding) if Config.instance.verbose
 
       authors = retrieve_authors
       authors.each do |author|
@@ -126,8 +126,6 @@ module Ballantine
 
     private
 
-    def conf = Config.instance
-
     # @param [String] name
     # @return [String] hash
     def check_tag(name)
@@ -140,13 +138,13 @@ module Ballantine
 
     # @return [String]
     def check_format
-      case conf.print_type
+      case Config.instance.print_type
       when Config::TYPE_TERMINAL
         " - " + "%h".yellow + " %<(#{ljust})%s " + "#{url}/commit/%H".gray
       when Config::TYPE_SLACK
         "\\\`<#{url}/commit/%H|%h>\\\` %s - %an"
       else
-        raise AssertionFailed, "Unknown print type: #{conf.print_type}"
+        raise AssertionFailed, "Unknown print type: #{Config.instance.print_type}"
       end
     end
 

--- a/lib/ballantine/version.rb
+++ b/lib/ballantine/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ballantine
-  VERSION = "0.1.5-rc2"
+  VERSION = "0.1.5"
 end

--- a/spec/lib/ballantine/cli_spec.rb
+++ b/spec/lib/ballantine/cli_spec.rb
@@ -16,7 +16,7 @@ describe Ballantine::CLI do
     it "returns ballantine config file" do
       expect(@cli.init).to be_truthy
       expect(Dir[file_path]).to eq([file_path])
-      expect(JSON.parse(File.read(file_path))).to eq({})
+      expect(JSON.parse(File.read(file_path))).to eq(Ballantine::Config.instance.send(:empty_data))
     end
 
     context "already init" do
@@ -34,7 +34,7 @@ describe Ballantine::CLI do
         it "returns ballantine config file" do
           expect(@cli.init).to be_truthy
           expect(Dir[file_path]).to eq([file_path])
-          expect(JSON.parse(File.read(file_path))).to eq({})
+          expect(JSON.parse(File.read(file_path))).to eq(Ballantine::Config.instance.send(:empty_data))
         end
       end
     end

--- a/spec/lib/ballantine/cli_spec.rb
+++ b/spec/lib/ballantine/cli_spec.rb
@@ -3,15 +3,15 @@
 require "spec_helper"
 
 describe Ballantine::CLI do
-  before(:each) do
-    @cli = Ballantine::CLI.new
+  before do
+    @cli = described_class.new
   end
 
   context "init" do
     let(:file_name) { Ballantine::Config::FILE_BALLANTINE_CONFIG }
     let(:file_path) { "./#{file_name}" }
 
-    after(:each) { File.delete(file_path) }
+    after { File.delete(file_path) }
 
     it "returns ballantine config file" do
       expect(@cli.init).to be_truthy
@@ -20,7 +20,7 @@ describe Ballantine::CLI do
     end
 
     context "already init" do
-      before(:each) { @cli.init }
+      before { @cli.init }
 
       it "raises error" do
         expect { @cli.init }.to raise_error(Ballantine::NotAllowed) do |e|
@@ -29,7 +29,7 @@ describe Ballantine::CLI do
       end
 
       context "with force option" do
-        before(:each) { @cli.options = { "force" => true }.freeze }
+        before { @cli.options = { "force" => true }.freeze }
 
         it "returns ballantine config file" do
           expect(@cli.init).to be_truthy


### PR DESCRIPTION
### Summary
- Add config: raise uncommitted
  - When it is true, it raises NotAllowed error.
  - When it is false, it will be stashsed uncommitted files before execution.
- Do not print error backtrace
  - If you want to trace backtrace, use `verbose` option.